### PR TITLE
Fixed null addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,4 @@ ASALocalRun/
 .mfractor/
 /src/FluffySpoon.AspNet.NGrok.Sample/ngrok.exe
 *.zip
+**/ngrok.exe

--- a/src/FluffySpoon.AspNet.NGrok.Sample/Startup.cs
+++ b/src/FluffySpoon.AspNet.NGrok.Sample/Startup.cs
@@ -25,8 +25,6 @@ namespace FluffySpoon.AspNet.NGrok.Sample
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            app.UseNGrok();
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -37,7 +35,6 @@ namespace FluffySpoon.AspNet.NGrok.Sample
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
-            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
             app.UseRouting();

--- a/src/FluffySpoon.AspNet.NGrok/NgrokAspNetCoreExtensions.cs
+++ b/src/FluffySpoon.AspNet.NGrok/NgrokAspNetCoreExtensions.cs
@@ -35,11 +35,5 @@ namespace FluffySpoon.AspNet.NGrok
             services.AddSingleton<INGrokHostedService>(p => p.GetRequiredService<NGrokHostedService>());
             services.AddSingleton<IHostedService>(p => p.GetRequiredService<NGrokHostedService>());
         }
-
-        public static void UseNGrok(this IApplicationBuilder builder)
-        {
-            var ngrokService = builder.ApplicationServices.GetRequiredService<NGrokHostedService>();
-			ngrokService.InjectServerAddressesFeature(builder.ServerFeatures.Get<IServerAddressesFeature>());
-        }
 	}
 }


### PR DESCRIPTION
I resolved the null address issue by waiting for `IApplicationLifetime.ApplicationStarted` to fire. This seems to be the right hook to guarantee `IServerAddressesFeature` is populated.

I copied your master branch to `fs-master` on the original repo. Once you review this PR, I'm comfortable merging `fs-master` to `develop`. From there we can both work out of `develop` until we're ready to push out the next official NuGet release. 

I already have another branch, `fs-master-rename`, with the renaming already complete. Once we've merged this PR, we can merge #21, then lastly we can merge to `develop` via #20. 

Merge order:
`resolved-null` (#19) -> `fs-master-rename` (#21) -> `fs-master` (#20) -> `develop`

Thanks again for the improvements! I enjoy the UI updates you've made, as well as the `IHostedService` implementation. Let me know if you have any other improvements in mind. Since you are now a maintainer, let's plan to have us review eachother's PRs. 