### PR TITLE
Ci testing integration

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,8 +47,16 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
-      #- name: Test
-      #  run: dotnet test --no-restore --verbosity normal
+      - name: Run Tests and Generate Coverage Report
+        run: |
+          cd ./test/Ngrok.AspNetCore.UnitTests
+          dotnet test /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --no-restore --verbosity normal
+
+      - name: Publish coverage report to coveralls.io
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./test/Ngrok.AspNetCore.UnitTests/TestResults/coverage.info 
 
       - name: Pack
         run: |

--- a/test/Ngrok.ApiClient.IntegrationTests/Ngrok.ApiClient.IntegrationTests.csproj
+++ b/test/Ngrok.ApiClient.IntegrationTests/Ngrok.ApiClient.IntegrationTests.csproj
@@ -8,14 +8,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="coverlet.msbuild" Version="2.9.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="1.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/test/Ngrok.ApiClient.IntegrationTests/packages.lock.json
+++ b/test/Ngrok.ApiClient.IntegrationTests/packages.lock.json
@@ -2,11 +2,11 @@
   "version": 1,
   "dependencies": {
     ".NETCoreApp,Version=v3.1": {
-      "coverlet.collector": {
+      "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[1.2.0, )",
-        "resolved": "1.2.0",
-        "contentHash": "ZB+EGXsVBIn8cew7D3S2c+rgIlokKv1dSwsXEoiFQaNXF/BSxp9Rlfz/jV1ehSWH5XpLitfRxFNW3ok7uPDOXA=="
+        "requested": "[2.9.0, )",
+        "resolved": "2.9.0",
+        "contentHash": "t+2du2q+z0FFklyP6HGSoKssRj0NequInLvgQ9rtxHskbgmAENxgt83eTQSRyxJ8DAThW8WOYhOuhuXIs//ZyA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/test/Ngrok.AspNetCore.UnitTests/Ngrok.AspNetCore.UnitTests.csproj
+++ b/test/Ngrok.AspNetCore.UnitTests/Ngrok.AspNetCore.UnitTests.csproj
@@ -8,10 +8,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="coverlet.msbuild" Version="2.9.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
 		<PackageReference Include="xunit" Version="2.4.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-		<PackageReference Include="coverlet.collector" Version="1.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/Ngrok.AspNetCore.UnitTests/packages.lock.json
+++ b/test/Ngrok.AspNetCore.UnitTests/packages.lock.json
@@ -2,11 +2,11 @@
   "version": 1,
   "dependencies": {
     ".NETCoreApp,Version=v3.1": {
-      "coverlet.collector": {
+      "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[1.0.1, )",
-        "resolved": "1.0.1",
-        "contentHash": "RAuno8s7DBGo2IdV/1d8YSnXMd/728K3PBT5R6/kfGx1yunBZmavlaFQfhGe7Q7N2nUMkvVET+7ITn3+KSg+Uw=="
+        "requested": "[2.9.0, )",
+        "resolved": "2.9.0",
+        "contentHash": "t+2du2q+z0FFklyP6HGSoKssRj0NequInLvgQ9rtxHskbgmAENxgt83eTQSRyxJ8DAThW8WOYhOuhuXIs//ZyA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",


### PR DESCRIPTION
This PR is for adding testing back into the CI build for the develop branch, and adding code coverage to coveralls.io. Two changes have been made to accomplish this.

1. Removed `coverlet.collect` from the Integration and Unit test projects and replaced it with `coverlet.msbuild`. This is to output the coverage results in the lcov format coveralls.io expexts. When outputting the results of `coverlet.collect`, it was in an XML format and there doesn't appear to be any command line arguments to change this.

2. Added two more jobs to the `ci-build.yml` file to run the unit tests and generate the code coverage file, and another to send that file to coveralls.io.